### PR TITLE
Add help page and link it across the site

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -105,7 +105,7 @@
 
     <footer class="site-footer">
       <div>© 2025 ПсихоИгры</div>
-      <div><a href="/app">Игры</a></div>
+      <div><a href="/app">Игры</a> • <a href="/help">Помощь</a></div>
     </footer>
 
     <script>

--- a/help.html
+++ b/help.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Помощь • ПсихоИгры</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>Помощь и FAQ</h1>
+      <p class="subtitle">Цели, инструкции и ответы на вопросы</p>
+      <div class="controls"><a href="/app" class="link">К играм</a></div>
+    </header>
+
+    <main class="layout" style="grid-template-columns:1fr;">
+      <section class="card">
+        <h2>Цели проекта</h2>
+        <p>Платформа предназначена для тренировки когнитивных навыков детей с помощью простых психологических игр.</p>
+      </section>
+
+      <section class="card">
+        <h2>Инструкции по играм</h2>
+        <ul>
+          <li><strong>Реакция:</strong> ждите зелёного сигнала и нажимайте как можно быстрее.</li>
+          <li><strong>Струп:</strong> выбирайте цвет написания слова, игнорируя текст.</li>
+          <li><strong>N-back:</strong> ищите совпадения с буквой, появившейся два шага назад.</li>
+          <li><strong>Память (сетка):</strong> запоминайте расположение подсвеченных клеток.</li>
+          <li><strong>Саймон:</strong> повторяйте последовательность сигналов.</li>
+          <li><strong>Go/No-Go:</strong> реагируйте только на зелёные круги.</li>
+          <li><strong>Дыхание:</strong> следуйте циклу вдох — задержка — выдох.</li>
+        </ul>
+      </section>
+
+      <section class="card">
+        <h2>Частые вопросы</h2>
+        <h3>Как сохранить прогресс?</h3>
+        <p>Результаты сохраняются локально в браузере. Для централизованного хранения используйте кабинет.</p>
+        <h3>Не могу войти в систему</h3>
+        <p>Убедитесь, что введённые email и пароль верны. При необходимости зарегистрируйтесь заново.</p>
+        <h3>Как связаться с поддержкой?</h3>
+        <p>Напишите нам на <a href="mailto:support@example.com">support@example.com</a>.</p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>© 2025 ПсихоИгры</div>
+      <div><a href="/app">Игры</a></div>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
 
     <footer class="site-footer">
       <div>© 2025 ПсихоИгры • Локальное сохранение прогресса</div>
-      <div><a href="#" id="to-top">Наверх ↑</a></div>
+      <div><a href="/help">Помощь</a> • <a href="#" id="to-top">Наверх ↑</a></div>
     </footer>
 
     <script type="module" src="/js/app.js"></script>

--- a/login.html
+++ b/login.html
@@ -78,7 +78,7 @@
 
     <footer class="site-footer">
       <div>© 2025 ПсихоИгры</div>
-      <div><a href="/app">К играм →</a></div>
+      <div><a href="/app">К играм →</a> • <a href="/help">Помощь</a></div>
     </footer>
 
     <script>

--- a/server.js
+++ b/server.js
@@ -345,6 +345,10 @@ async function main() {
     res.sendFile(path.join(__dirname, 'intake.html'));
   });
 
+  app.get('/help', (req, res) => {
+    res.sendFile(path.join(__dirname, 'help.html'));
+  });
+
   app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));
 }
 


### PR DESCRIPTION
## Summary
- add dedicated help.html with project goals, game instructions and FAQ
- expose GET /help route on the server
- link help page from index, login and dashboard screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68974e48bb608329ac2c88bb7d1641fb