### PR TITLE
feat: add password reset flow

### DIFF
--- a/forgot.html
+++ b/forgot.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Восстановление пароля • ПсихоИгры</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <style>
+      .auth-card { max-width: 520px; margin: 40px auto; }
+      .field { display: grid; gap: 6px; margin-bottom: 12px; }
+      .field input { padding: 10px 12px; border-radius: 10px; border: 1px solid #3a3f82; background: #1b1f4a; color: var(--text); }
+      .muted { color: var(--muted); }
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>ПсихоИгры</h1>
+      <p class="subtitle">Сброс пароля</p>
+    </header>
+    <main class="layout" style="grid-template-columns: 1fr;">
+      <section class="card auth-card">
+        <h2>Забыли пароль</h2>
+        <div class="field">
+          <label>Email</label>
+          <input id="email" type="email" placeholder="you@example.com" />
+        </div>
+        <div class="controls">
+          <button id="btn" class="primary">Отправить ссылку</button>
+          <span id="msg" class="muted"></span>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div>© 2025 ПсихоИгры</div>
+      <div><a href="/login.html">← Войти</a></div>
+    </footer>
+    <script>
+      async function post(url, body) {
+        const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        const data = await res.json().catch(()=>({}));
+        if (!res.ok) throw new Error(data.error || 'error');
+        return data;
+      }
+      document.getElementById('btn').addEventListener('click', async () => {
+        const email = document.getElementById('email').value.trim();
+        const msg = document.getElementById('msg');
+        msg.textContent = 'Отправка…';
+        try {
+          await post('/api/auth/forgot', { email });
+          msg.textContent = 'Ссылка отправлена (проверьте лог сервера)';
+        } catch (e) {
+          msg.textContent = 'Ошибка: ' + e.message;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/login.html
+++ b/login.html
@@ -34,6 +34,7 @@
           <button id="btn-login" class="primary">Войти</button>
           <span id="login-msg" class="muted"></span>
         </div>
+        <div style="margin-top:8px;"><a href="/forgot.html">Забыли пароль?</a></div>
       </section>
 
       <section class="card auth-card">

--- a/reset.html
+++ b/reset.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Сброс пароля • ПсихоИгры</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <style>
+      .auth-card { max-width: 520px; margin: 40px auto; }
+      .field { display: grid; gap: 6px; margin-bottom: 12px; }
+      .field input { padding: 10px 12px; border-radius: 10px; border: 1px solid #3a3f82; background: #1b1f4a; color: var(--text); }
+      .muted { color: var(--muted); }
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>ПсихоИгры</h1>
+      <p class="subtitle">Сброс пароля</p>
+    </header>
+    <main class="layout" style="grid-template-columns: 1fr;">
+      <section class="card auth-card">
+        <h2>Новый пароль</h2>
+        <div class="field">
+          <label>Пароль</label>
+          <input id="password" type="password" />
+        </div>
+        <div class="controls">
+          <button id="btn" class="primary">Сбросить</button>
+          <span id="msg" class="muted"></span>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div>© 2025 ПсихоИгры</div>
+      <div><a href="/login.html">← Войти</a></div>
+    </footer>
+    <script>
+      const params = new URLSearchParams(location.search);
+      const token = params.get('token');
+      async function post(url, body) {
+        const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        const data = await res.json().catch(()=>({}));
+        if (!res.ok) throw new Error(data.error || 'error');
+        return data;
+      }
+      document.getElementById('btn').addEventListener('click', async () => {
+        const password = document.getElementById('password').value;
+        const msg = document.getElementById('msg');
+        msg.textContent = 'Отправка…';
+        try {
+          await post('/api/auth/reset', { token, password });
+          msg.textContent = 'Пароль изменён, можно войти.';
+        } catch (e) {
+          msg.textContent = 'Ошибка: ' + e.message;
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add password_resets table and implement forgot/reset API endpoints
- expose forgot and reset password pages with simple forms
- link to password recovery from login screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68974e3c5c248329a938eb9ea941ce95